### PR TITLE
Fix build - lit/decorators imported as .js

### DIFF
--- a/src/components/sunCard/SunCard.ts
+++ b/src/components/sunCard/SunCard.ts
@@ -1,6 +1,6 @@
 import { HomeAssistant } from 'custom-card-helpers'
 import { CSSResult, LitElement, TemplateResult } from 'lit'
-import { customElement,  state } from 'lit/decorators'
+import { customElement,  state } from 'lit/decorators.js'
 
 import cardStyles from '../../cardStyles'
 import { Constants } from '../../constants'

--- a/src/components/sunCardEditor/SunCardEditor.ts
+++ b/src/components/sunCardEditor/SunCardEditor.ts
@@ -1,6 +1,6 @@
 import { HomeAssistant, LovelaceCardEditor } from 'custom-card-helpers'
 import { CSSResult, LitElement, TemplateResult } from 'lit'
-import { customElement, property } from 'lit/decorators'
+import { customElement, property } from 'lit/decorators.js'
 
 import cardStyles from '../../cardStyles'
 import { ESunCardI18NKeys,ISunCardConfig } from '../../types'


### PR DESCRIPTION
Fix build - lit/decorators seems to require being imported as lit/decorators.js now (something to do with changes in the TS world)