### PR TITLE
Add Bulgarian translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Note: If you get an error similar to this `Custom element doesn't exist` you wil
 <details>
 <summary><sup>1</sup> Supported languages</summary>
 
+- `bg` Bulgarian
 - `cs` Czech
 - `da` Danish
 - `de` German

--- a/src/assets/localization/languages/bg.json
+++ b/src/assets/localization/languages/bg.json
@@ -1,0 +1,12 @@
+{
+  "azimuth": "Азимут",
+  "dawn": "Зора",
+  "dusk": "Здрач",
+  "elevation": "Височина",
+  "noon": "Пладне",
+  "sunrise": "Изгрев",
+  "sunset": "Залез",
+  "errors": {
+    "SunIntegrationNotFound": "Интеграцията Sun не е намерена"
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,4 @@
+import bg from './assets/localization/languages/bg.json'
 import ca from './assets/localization/languages/ca.json'
 import cs from './assets/localization/languages/cs.json'
 import da from './assets/localization/languages/da.json'
@@ -81,7 +82,7 @@ export class Constants {
   }
 
   static readonly LOCALIZATION_LANGUAGES: Record<string, TSunCardI18NKeys> = {
-    ca, cs, da, de, en, es, et, fi, fr, he, hu, is, it, lt, nb, nl, nn, pl, 'pt-BR': ptBR, ru, sk, sl, sv, tr, uk
+    bg, ca, cs, da, de, en, es, et, fi, fr, he, hu, is, it, lt, nb, nl, nn, pl, 'pt-BR': ptBR, ru, sk, sl, sv, tr, uk
   }
 
   static readonly FALLBACK_LOCALIZATION = en

--- a/tests/unit/utils/I18.spec.ts
+++ b/tests/unit/utils/I18.spec.ts
@@ -61,19 +61,18 @@ describe('I18N', () => {
           const date = new Date()
           const result = i18n.formatDateAsTime(date)
 
-          const periodRegex = /[^0-9.:\s]/gm
-          if (use12hourClock === false) {
-            expect(result.toLocaleLowerCase()).not.toMatch(periodRegex)
-          }
-
-          if (use12hourClock === true) {
-            expect(result.toLocaleLowerCase()).toMatch(periodRegex)
-          }
-
-          const timeRegex = /\d{1,2}[:.]\d{1,2}|[AMP]+/g
+          const timeRegex = /\d{1,2}[:.]\d{2}/g
           expect(result).toMatch(timeRegex)
         })
       }
+      it(`formats time correctly with different languages for 12h vs 24h clock [${language}]`, () => {
+        const date = new Date()
+        const i18n_12 = new I18N(language, true)
+        const i18n_24 = new I18N(language, false)
+        const result_12 = i18n_12.formatDateAsTime(date)
+        const result_24 = i18n_24.formatDateAsTime(date)
+        expect(result_12).not.toEqual(result_24)
+      })
     }
   })
 


### PR DESCRIPTION
- Refactored time tests to not be sensitive about the locale as Bulgarian reports the 24h clock with an additional letter that conflicted with the test logic