### PR TITLE
Update actions/checkout to v3

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -17,7 +17,7 @@ jobs:
   validate:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - name: HACS validation
         uses: "hacs/action@main"
         with:


### PR DESCRIPTION
I've already tested a fork from the original sun-card repo against the latest repo and it passed.